### PR TITLE
Flutter v2.10.x 버전에서의 Kotlin Version 오류 해결

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.kakao.sdk.flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
현재 플러터 v2.10.x 버전에서는, 코틀린 버전이 일정 버전 이상이 아닐 경우 오류를 내며 어플리케이션이 정상적으로 실행되지 않습니다.
이를 해결하기 위해, 플러그인와 예제 앱의 Kotiln 버전을 업데이트하여 커밋을 진행하였습니다.

다른 한 개의 커밋인 compileSdkVersion 수정은, 예제 앱의 정상 구동을 위해 수정을 진행하였습니다.