### PR TITLE
카카오톡 로그인 시, 타입캐스팅으로 인한 에러 수정 (iOS)

### DIFF
--- a/packages/kakao_flutter_sdk_common/ios/Classes/SwiftKakaoFlutterSdkPlugin.swift
+++ b/packages/kakao_flutter_sdk_common/ios/Classes/SwiftKakaoFlutterSdkPlugin.swift
@@ -18,18 +18,25 @@ public class SwiftKakaoFlutterSdkPlugin: NSObject, FlutterPlugin, ASWebAuthentic
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        func castArguments(_ arguments: Any?) -> Dictionary<String, String> {
+            var args = arguments as! Dictionary<String, Any>
+            let isPopup = (args["is_popup"] as? Bool) ?? true
+            args["is_popup"] = (isPopup) ? "YES" : "NO"
+            return args as! Dictionary<String, String>
+        }
+
         switch call.method {
         case "getOrigin":
             result(Utility.origin())
         case "getKaHeader":
             result(Utility.kaHeader())
         case "launchBrowserTab":
-            let args = call.arguments as! Dictionary<String, String>
+            let args = castArguments(call.arguments)
             let url = args["url"]
             let redirectUri = args["redirect_uri"]
             launchBrowserTab(url: url!, redirectUri: redirectUri, result: result)
         case "authorizeWithTalk":
-            let args = call.arguments as! Dictionary<String, String>
+            let args = castArguments(call.arguments)
             let sdkVersion = args["sdk_version"]
             let clientId = args["client_id"]
             let redirectUri = args["redirect_uri"]
@@ -51,21 +58,21 @@ public class SwiftKakaoFlutterSdkPlugin: NSObject, FlutterPlugin, ASWebAuthentic
             }
             result(UIApplication.shared.canOpenURL(naviUrl))
         case "launchKakaoTalk":
-            let args = call.arguments as! Dictionary<String, String>
+            let args = castArguments(call.arguments)
             let uri = args["uri"]
             launchKakaoTalk(uri: uri!, result: result)
         case "isKakaoTalkSharingAvailable":
             let isKakaoTalkSharingAvailable = UIApplication.shared.canOpenURL(URL(string:"kakaolink://send")!)
             result(isKakaoTalkSharingAvailable)
         case "navigate":
-            let args = call.arguments as! Dictionary<String, String>
+            let args = castArguments(call.arguments)
             let appKey = args["app_key"]
             let extras = args["extras"]
             let params = args["navi_params"]
             let url = Utility.makeUrlWithParameters("kakaonavi-sdk://navigate", parameters: ["extras": extras!, "param": params!, "appkey": appKey!, "apiver": "1.0"])
             UIApplication.shared.open(url!, options: [:], completionHandler: nil)
         case "shareDestination":
-            let args = call.arguments as! Dictionary<String, String>
+            let args = castArguments(call.arguments)
             let appKey = args["app_key"]
             let extras = args["extras"]
             let params = args["navi_params"]


### PR DESCRIPTION
- CLA 구글폼 모두 작성한 상태입니다. 이메일로도 문의 드린 후, PR 요청드립니다.

- 동작환경
```
[✓] Flutter (Channel stable, 3.3.0, on macOS 12.6 21G115 darwin-arm, locale ko-KR)
[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.0)
[✓] Xcode - develop for iOS and macOS (Xcode 14.0.1)
[✓] Chrome - develop for the web
[✓] Android Studio (version 2021.2)
[✓] Connected device (4 available)
[✓] HTTP Host Availability
```

기기: 실제 Device (iPhone 11 Pro iOS 14.3ver)

- 에러메시지
```
Could not cast value of type '__NSCFBoolean' (0x1efb2dc70) to 'NSString' (0x1efb39170).
Could not cast value of type '__NSCFBoolean' (0x1efb2dc70) to 'NSString' (0x1efb39170).
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00000001bae1c414 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x1bae1c414 <+8>:  b.lo   0x1bae1c434               ; <+40>
    0x1bae1c418 <+12>: pacibsp 
    0x1bae1c41c <+16>: stp    x29, x30, [sp, #-0x10]!
    0x1bae1c420 <+20>: mov    x29, sp
Target 0: (Runner) stopped.
Lost connection to device.
```

## 디버깅 과정

- Redirect 방식 에러 확인
(https://developers.kakao.com/docs/latest/ko/kakaologin/flutter#authorize-through-kakaotalk)
Flutter 에서 KakaoTalk Login 시, `SwiftKakaoFlutterSdkPlugin` 의 메소드 중 `handel(call:result:)` 메소드가 호출됩니다. 그 중 RedirectURI 방식으로 시도하게 되면, "launchBrowserTab" 이름으로 된 메소드가 호출됩니다. 호출 시, `FlutterMethodCall` 로부터 전달받은 argument 는 다음과 같습니다.
(노랑색 박스 부분을 참고하시면 됩니다.)

<img width="878" alt="image" src="https://user-images.githubusercontent.com/65879950/193995881-0772e4ee-1636-4468-9c90-2535b16bc14f.png">


현재 에러가 발생하는 부분은 `_arguments` 에 인덱스 2 에 있는 {"is_popup" : YES } 데이터 입니다. 이 데이터를 `Dictionary<String,String>` 으로 강제 타입캐스팅 시, 크래쉬가 발생하게 됩니다. Flutter -> iOS 로 데이터를 전달하는 과정에서 {"is_popup" : "YES" } 로 전달한 데이터가 String 을 Boolean 으로 인식해서 {"is_popup" : YES } 로 전환되어 발생한 에러로 판단됩니다.


- 카카오톡 로그인 방식 에러 확인
(https://developers.kakao.com/docs/latest/ko/kakaologin/flutter#login-through-kakaotalk)

위와 동일하게 arguments 에서 캐스팅을 진행하는데, 다음과 같은 데이터가 출력됩니다.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/65879950/193995926-02910ecd-81ab-4b9d-8aab-41a1e5414416.png">


마찬가지로 "is_popup" value 가 String 이 아니라서 다음과 같에 크래시가 나오게됩니다.

<img width="879" alt="image" src="https://user-images.githubusercontent.com/65879950/193995962-1d3dc36a-3c76-48c0-9cc0-3bdaf00956b8.png">


- 코드

```swift
public func handle(_ call: FlutterMethodCall, result: ...) {
	func castArguments(_ arguments: Any?) -> Dictionary<String, String> {  
		var args = arguments as! Dictionary<String, Any>  
	    let isPopup = (args["is_popup"] as? Bool) ?? true  
	    args["is_popup"] = (isPopup) ? "YES" : "NO"  
	    return args as! Dictionary<String, String>  
	}
	...
	switch call.method {
		case "launchBrowserTab":
		let args = castArguments(call.arguments)
		...

	}
}
```

- 기존에 `Dictionary<String, String>` 캐스팅에서 에러가 발생했으므로, 에러가 발생한 문자열 인덱스인 "is_popup" 에 대해서 Boolean -> String 으로 변경해주는 메소드를 추가했습니다. "launchBrowserTab" 케이스에서만 사용되는 것이 아니므로 메소드로 구성했습니다.