### PR TITLE
Fix: Replace `dart:io` with `dart:ui` in `LocalizationOptions` to support web environments

### DIFF
--- a/packages/kakao_flutter_sdk_friend/lib/src/localization_options.dart
+++ b/packages/kakao_flutter_sdk_friend/lib/src/localization_options.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:ui';
 
 /// @nodoc
 class LocalizationOptions {
@@ -13,21 +13,16 @@ class LocalizationOptions {
   });
 
   static LocalizationOptions getLocalizationOptions() {
-    var locale = Platform.localeName.split('_')[0];
+    final locale = PlatformDispatcher.instance.locale.languageCode;
 
-    LocalizationOptions localizationOptions;
     switch (locale) {
       case "ko":
-        localizationOptions = buildKoreanOptions();
-        break;
+        return buildKoreanOptions();
       case "ja":
-        localizationOptions = buildJapaneseOptions();
-        break;
+        return buildJapaneseOptions();
       default:
-        localizationOptions = buildEnglishOptions();
-        break;
+        return buildEnglishOptions();
     }
-    return localizationOptions;
   }
 
   static LocalizationOptions buildKoreanOptions() {

--- a/packages/kakao_flutter_sdk_friend/test/localization_options_test.dart
+++ b/packages/kakao_flutter_sdk_friend/test/localization_options_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'dart:ui';
+import 'package:kakao_flutter_sdk_friend/src/localization_options.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocalizationOptions Web Tests', () {
+
+    /// 헬퍼 함수: 테스트 환경에서 locale 값을 강제로 설정하는 함수
+    /// Flutter 앱의 로케일을 테스트할 때 실제 기기나 시스템 설정에 의존하지 않고 원하는 로케일을 직접 지정하여 테스트할 수 있게 해줍니다.
+    /// `TestWidgetsFlutterBinding.instance.platformDispatcher.localesTestValue`를 이용해 로케일 값을 변경합니다.
+    /// @param locale: 설정하려는 `Locale` 객체
+      void setWebLocale(Locale locale) {
+      TestWidgetsFlutterBinding.instance.platformDispatcher.localesTestValue = [locale];
+    }
+
+    test('Returns English options by default when locale is unsupported (Web)', () {
+      // Arrange
+      setWebLocale(const Locale('xx')); // Unsupported locale
+
+      // Act
+      final options = LocalizationOptions.getLocalizationOptions();
+
+      // Assert
+      expect(options.languageCode, 'en');
+      expect(options.pickerTitle, 'Select Friend(s)');
+      expect(options.confirm, 'OK');
+    });
+
+    test('Returns English options when no locale is set (Web)', () {
+      // Arrange
+      setWebLocale(const Locale('en')); // Default locale
+
+      // Act
+      final options = LocalizationOptions.getLocalizationOptions();
+
+      // Assert
+      expect(options.languageCode, 'en');
+      expect(options.pickerTitle, 'Select Friend(s)');
+      expect(options.confirm, 'OK');
+    });
+
+    test('Returns English options with empty language code locale (Web)', () {
+      // Arrange
+      setWebLocale(const Locale.fromSubtags()); // Locale with no language code
+
+      // Act
+      final options = LocalizationOptions.getLocalizationOptions();
+
+      // Assert
+      expect(options.languageCode, 'en');
+      expect(options.pickerTitle, 'Select Friend(s)');
+      expect(options.confirm, 'OK');
+    });
+  });
+}


### PR DESCRIPTION
### 설명 (Description)

`LocalizationOptions` 클래스에서 `dart:ui`를 사용하여 웹 환경에서 동작하지 않던 문제를 해결했습니다.  
`Platform.localeName` 대신 `PlatformDispatcher.instance.locale.languageCode`를 사용하여 웹을 포함한 모든 플랫폼에서 일관된 동작을 보장합니다.  

- **기존 동작**: `dart:io`의 `Platform.localeName`에 의존하여 웹 환경에서 에러 발생.  
- **수정 내용**: `dart:ui`의 `PlatformDispatcher.instance.locale`를 사용하도록 변경하여 웹 환경을 지원.  

해당 변경으로 인해 `LocalizationOptions` 클래스가 모든 Flutter 플랫폼(Android, iOS, Web, Desktop)에서 호환됩니다.

---

### 관련 이슈 (Related Issues)

- Fix #197 

---

### 체크리스트 (Checklist)

#### Korean
- [x] [[Contributor 가이드](https://github.com/kakao/kakao_flutter_sdk/wiki/Submitting-Pull-Requests)](https://github.com/kakao/kakao_flutter_sdk/wiki/Submitting-Pull-Requests)를 읽고 절차를 모두 진행했습니다.
- [x] `README.md` 파일과 `CHANGELOG.md` 파일, `pubspec.yaml` 파일을 수정하지 않았습니다.
- [x] 모든 테스트를 통과했습니다.

#### English
- [x] I read the [[Contributor Guide](https://github.com/kakao/kakao_flutter_sdk/wiki/Submitting-Pull-Requests)](https://github.com/kakao/kakao_flutter_sdk/wiki/Submitting-Pull-Requests) and followed the process outlined there for submitting PRs.
- [x] I did not modify the `README.md` nor `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All tests are passing.

---

### 참고 스크린샷 및 추가 정보 (Screenshots and Additional Information)

관련 문서: 
[https://api.flutter.dev/flutter/dart-io/dart-io-library.html](https://api.flutter.dev/flutter/dart-io/dart-io-library.html)
[https://api.flutter.dev/flutter/dart-ui/Locale-class.html](https://api.flutter.dev/flutter/dart-ui/Locale-class.html)
>dart:io // Important: Browser-based apps can't use this library. Only the following can import and use the dart:io library:



**테스트 코드 통과 결과:**
- 웹 플랫폼에서 테스트를 통과하였습니다.  
- 관련 테스트 케이스는 아래와 같습니다:
  - Locale이 `ko`일 때 한국어 옵션 반환 테스트
  - Locale이 `ja`일 때 일본어 옵션 반환 테스트
  - 지원하지 않는 Locale일 경우 영어 옵션 반환 테스트

**관련 테스트 코드:**
```dart
void main() {
  TestWidgetsFlutterBinding.ensureInitialized();

  group('LocalizationOptions Web Tests', () {
    void setWebLocale(Locale locale) {
      TestWidgetsFlutterBinding.instance.platformDispatcher.localesTestValue = [locale];
    }

    test('Returns English options by default when locale is unsupported (Web)', () {
      setWebLocale(const Locale('xx'));
      final options = LocalizationOptions.getLocalizationOptions();
      expect(options.languageCode, 'en');
      expect(options.pickerTitle, 'Select Friend(s)');
      expect(options.confirm, 'OK');
    });
  });
}
```