### PR TITLE
fix(android): add Custom Tabs timeout fallback to prevent blank scree…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+- Android: Fixed a bug where Login with Kakao Account gets stuck on a blank screen on devices
+  where `bindCustomTabsService` binds successfully but `onCustomTabsServiceConnected` never fires
+  (commonly observed on Xiaomi MIUI with Brave, Samsung Internet, or other third-party browsers
+  set as default). A 3-second timeout now triggers a fallback to a direct `Intent.ACTION_VIEW`
+  browser launch so the login page always opens.
+
 ## 1.10.0
 
 - Added API to select login method.

--- a/packages/kakao_flutter_sdk_common/android/src/main/kotlin/com/kakao/sdk/flutter/CustomTabsActivity.kt
+++ b/packages/kakao_flutter_sdk_common/android/src/main/kotlin/com/kakao/sdk/flutter/CustomTabsActivity.kt
@@ -6,6 +6,8 @@ import android.content.ServiceConnection
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.ResultReceiver
 import android.util.Log
 
@@ -15,6 +17,12 @@ open class CustomTabsActivity : Activity() {
     private var customTabsOpened = false
     private var resultReceiver: ResultReceiver? = null
     private var activityName: String? = null
+
+    // Guards against OEM browsers (e.g. Brave, Samsung Internet on Xiaomi MIUI) where
+    // bindCustomTabsService returns true but onCustomTabsServiceConnected never fires,
+    // leaving the user on a transparent empty activity indefinitely.
+    private val customTabsTimeoutHandler = Handler(Looper.getMainLooper())
+    private var customTabsBrowserOpened = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -71,13 +79,46 @@ open class CustomTabsActivity : Activity() {
 
     private fun openChromeCustomTab(uri: Uri) {
         try {
-            customTabsConnection = CustomTabsCommonClient.openWithDefault(this, uri)
+            customTabsConnection = CustomTabsCommonClient.openWithDefault(
+                context = this,
+                uri = uri,
+                onServiceConnected = {
+                    // Browser launched successfully — cancel the timeout fallback.
+                    customTabsBrowserOpened = true
+                    customTabsTimeoutHandler.removeCallbacksAndMessages(null)
+                },
+            )
         } catch (e: Exception) {
-            try {
-                CustomTabsCommonClient.open(this, uri)
-            } catch (e: Exception) {
-                sendError("EUNKNOWN", e.localizedMessage)
-            }
+            // No Custom Tabs browser found — fall back to a plain Intent.ACTION_VIEW launch.
+            openDirectBrowser(uri)
+            return
+        }
+
+        if (customTabsConnection != null) {
+            // bindCustomTabsService returned true (binding in progress) but
+            // onCustomTabsServiceConnected may never fire on some OEM devices.
+            // Schedule a fallback: if the browser has not opened within 3 seconds,
+            // fall back to a direct launch so the user is never stuck on an empty screen.
+            customTabsTimeoutHandler.postDelayed({
+                if (!customTabsBrowserOpened && !isFinishing) {
+                    Log.w(
+                        "CustomTabsActivity",
+                        "onCustomTabsServiceConnected not called within 3 s. " +
+                            "Falling back to direct browser launch. " +
+                            "This typically happens with Brave or Samsung Internet on " +
+                            "devices with aggressive background process management (e.g. Xiaomi MIUI).",
+                    )
+                    openDirectBrowser(uri)
+                }
+            }, CUSTOM_TABS_TIMEOUT_MS)
+        }
+    }
+
+    private fun openDirectBrowser(uri: Uri) {
+        try {
+            CustomTabsCommonClient.open(this, uri)
+        } catch (e: Exception) {
+            sendError("EUNKNOWN", e.localizedMessage)
         }
     }
 
@@ -100,7 +141,13 @@ open class CustomTabsActivity : Activity() {
 
     override fun onDestroy() {
         super.onDestroy()
+        customTabsTimeoutHandler.removeCallbacksAndMessages(null)
         customTabsConnection?.let { unbindService(it) }
+    }
+
+    companion object {
+        // How long to wait for onCustomTabsServiceConnected before falling back to open().
+        private const val CUSTOM_TABS_TIMEOUT_MS = 3_000L
     }
 
     override fun finishAndRemoveTask() {

--- a/packages/kakao_flutter_sdk_common/android/src/main/kotlin/com/kakao/sdk/flutter/CustomTabsClient.kt
+++ b/packages/kakao_flutter_sdk_common/android/src/main/kotlin/com/kakao/sdk/flutter/CustomTabsClient.kt
@@ -14,8 +14,22 @@ import androidx.browser.customtabs.CustomTabsService
 import androidx.browser.customtabs.CustomTabsServiceConnection
 
 object CustomTabsCommonClient {
+    /**
+     * Opens [uri] in a Custom Tabs browser using service pre-warming (warm path).
+     *
+     * @param onServiceConnected Optional callback invoked immediately after the browser
+     *   activity is launched via [CustomTabsServiceConnection.onCustomTabsServiceConnected].
+     *   Callers can use this to cancel a pending timeout that guards against the case where
+     *   [onCustomTabsServiceConnected] never fires (e.g. Brave / Samsung Internet on MIUI).
+     *
+     * @throws UnsupportedOperationException if no browser on the device supports Custom Tabs.
+     */
     @Throws(UnsupportedOperationException::class)
-    fun openWithDefault(context: Context, uri: Uri): ServiceConnection? {
+    fun openWithDefault(
+        context: Context,
+        uri: Uri,
+        onServiceConnected: (() -> Unit)? = null,
+    ): ServiceConnection? {
         val packageName = resolveCustomTabsPackage(context, uri)
             ?: throw UnsupportedOperationException("No browser supports custom tabs protocol on this device.")
         Log.d("CustomTabsCommonClient", "Choosing $packageName as custom tabs browser")
@@ -30,6 +44,9 @@ object CustomTabsCommonClient {
                 customTabsIntent.intent.data = uri
                 customTabsIntent.intent.setPackage(packageName)
                 context.startActivity(customTabsIntent.intent)
+                // Notify the caller that the browser was successfully launched so it can
+                // cancel any timeout fallback it may have scheduled.
+                onServiceConnected?.invoke()
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {


### PR DESCRIPTION
# fix(android): add Custom Tabs timeout fallback to prevent blank screen on OEM browsers

## Problem

On some Android devices, **Login with Kakao Account gets stuck on a blank/transparent screen**
and the browser never opens, leaving users unable to log in.

### Root cause

`CustomTabsCommonClient.openWithDefault()` calls `CustomTabsClient.bindCustomTabsService()` to
pre-warm the browser. `bindCustomTabsService` returns `true` (binding accepted), but
`onCustomTabsServiceConnected` **never fires** on certain device/browser combinations:

| Device        | Browser          | Behavior                                  |
|---------------|------------------|-------------------------------------------|
| Xiaomi MIUI   | Brave            | `onCustomTabsServiceConnected` never fires |
| Xiaomi MIUI   | Samsung Internet | `onCustomTabsServiceConnected` never fires |
| Various OEM   | Third-party default browser | Intermittent failure           |

The existing `catch` block in `openChromeCustomTab` never triggers because
`bindCustomTabsService` itself does not throw — it just silently stalls.

```
bindCustomTabsService(packageName, connection) → returns true ✓
  └─ onCustomTabsServiceConnected() ← NEVER CALLED on affected devices
       (browser window never opens, user is stuck forever)
```

## Fix

### `CustomTabsClient.kt` — add `onServiceConnected` callback

Added an optional `onServiceConnected: (() -> Unit)? = null` parameter to `openWithDefault`.
It is invoked inside `onCustomTabsServiceConnected` immediately after `startActivity` so callers
can observe whether the browser was actually launched.

```kotlin
// Before
fun openWithDefault(context: Context, uri: Uri): ServiceConnection?

// After
fun openWithDefault(
    context: Context,
    uri: Uri,
    onServiceConnected: (() -> Unit)? = null,  // ← new, optional → backward compatible
): ServiceConnection?
```

### `CustomTabsActivity.kt` — 3-second timeout → fallback to `open()`

After `openWithDefault` starts the service binding, a `Handler.postDelayed` callback fires
after **3 seconds**. If the browser has not been launched by then, it falls back to
`CustomTabsCommonClient.open()` — a direct `CustomTabsIntent.launchUrl()` call that is not
gated on the service connection and **always works**.

```
bindCustomTabsService() starts  ──────────────────────────────────────────────────────────┐
                                                                                           │
    onCustomTabsServiceConnected fires (normal)         3-second timeout fires (fallback)  │
           ↓                                                    ↓                          │
    startActivity → browser opens ✅              CustomTabsCommonClient.open() ✅         │
    cancel timeout                                browser opens via direct launch          │
```

The timeout is cancelled immediately when `onServiceConnected` is invoked, so there is
**zero overhead on devices where Custom Tabs works correctly**.

## Affected files

```
packages/kakao_flutter_sdk_common/android/src/main/kotlin/com/kakao/sdk/flutter/
  ├── CustomTabsClient.kt    — added onServiceConnected callback parameter
  └── CustomTabsActivity.kt  — added 3-second timeout + openDirectBrowser() fallback
```

## Testing

### Devices confirmed broken before fix / working after fix

- Xiaomi Redmi Note 12 (MIUI 14) — Brave browser as default
- Xiaomi Redmi Note 12 (MIUI 14) — Samsung Internet as default

### How to reproduce the original bug (before fix)

1. Set Brave or Samsung Internet as the default browser on a Xiaomi device.
2. Close the browser completely (remove from recents).
3. Call `UserApi.instance.loginWithKakaoAccount()`.
4. Observe: transparent `AuthCodeCustomTabsActivity` appears, browser never opens.

### How to verify the fix

Same steps as above — after the fix, the browser opens within ~3 seconds via the direct
fallback path. The log line below will appear:

```
W/CustomTabsActivity: onCustomTabsServiceConnected not called within 3 s.
    Falling back to direct browser launch.
    This typically happens with Brave or Samsung Internet on devices with
    aggressive background process management (e.g. Xiaomi MIUI).
```

## Backward compatibility

- `onServiceConnected` parameter defaults to `null` — **no breaking change**.
- The timeout fallback only activates when the pre-warming path stalls; on all other
  devices the code path is identical to the current behavior.
- `open()` (the fallback) produces the same visual result as Custom Tabs for the user.
